### PR TITLE
Xdebug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
                         - ./moj-node/server:/home/node/app/server
                         - ./moj-node/test:/home/node/app/test
                         - ./moj-node/assets:/home/node/app/assets
-        
+
         hub-fe:
                 image: mojdigitalstudio/digital-hub-fe
                 depends_on:
@@ -62,6 +62,7 @@ services:
                         PHP_UPLOAD_MAX_FILE_SIZE: 500M
                         PHP_POST_MAX_SIZE: 500M
                         SIMPLETEST_DB: mysql://hubdb_user:hubdb_pass@localhost/hubdb
+                        XDEBUG_IP: 127.0.0.1 # Replace with your machines IP: $ ipconfig getifaddr en0 
                 volumes:
                         - ./moj-be/:/var/www/html/
                 ports:

--- a/moj-be/Dockerfile
+++ b/moj-be/Dockerfile
@@ -10,10 +10,8 @@ RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir
 RUN docker-php-ext-install gd
 RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
-RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
-RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
+COPY /php/xdebug.ini /usr/local/etc/php/conf.d/
+
 
 #RUN composer update
 #RUN pecl install memcached

--- a/moj-be/Dockerfile
+++ b/moj-be/Dockerfile
@@ -5,7 +5,7 @@ COPY . /composer
 RUN composer install --ignore-platform-reqs
 
 FROM php:5.6-apache as build
-RUN apt-get update && apt-get upgrade -y && apt-get install vim unzip libpng-dev libmemcached-dev zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev mediainfo git -y
+RUN apt-get update && apt-get upgrade -y && apt-get install unzip libpng-dev libmemcached-dev zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev mediainfo git -y
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir
 RUN docker-php-ext-install gd

--- a/moj-be/Dockerfile
+++ b/moj-be/Dockerfile
@@ -5,10 +5,16 @@ COPY . /composer
 RUN composer install --ignore-platform-reqs
 
 FROM php:5.6-apache as build
-RUN apt-get update && apt-get upgrade -y && apt-get install unzip libpng-dev libmemcached-dev zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev mediainfo git -y
+RUN apt-get update && apt-get upgrade -y && apt-get install vim unzip libpng-dev libmemcached-dev zlib1g-dev libfreetype6-dev libjpeg62-turbo-dev mediainfo git -y
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir
 RUN docker-php-ext-install gd
+RUN pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug
+RUN echo 'zend_extension="/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so"' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini
+RUN echo 'xdebug.remote_connect_back=1' >> /usr/local/etc/php/php.ini
+
 #RUN composer update
 #RUN pecl install memcached
 #RUN docker-php-ext-enable memcached

--- a/moj-be/php/xdebug.ini
+++ b/moj-be/php/xdebug.ini
@@ -1,0 +1,7 @@
+xdebug.remote_enable=1
+xdebug.remote_handler=dbgp
+xdebug.remote_port=9000
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=0
+xdebug.idekey=docker
+xdebug.remote_host=${XDEBUG_IP}

--- a/moj-be/php/xdebug.ini
+++ b/moj-be/php/xdebug.ini
@@ -1,7 +1,7 @@
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
-xdebug.remote_autostart=1
+xdebug.remote_autostart=0
 xdebug.remote_connect_back=0
 xdebug.idekey=docker
 xdebug.remote_host=${XDEBUG_IP}

--- a/moj-be/phpinfo.php
+++ b/moj-be/phpinfo.php
@@ -1,1 +1,0 @@
-<?php phpinfo(); ?>


### PR DESCRIPTION
Added xDebug to the CMS (Drupal) container 
Added `moj-be/php/xdebug.ini` for easy config of xDebug
Added `XDEBUG_IP` environment variable for easy config of xDebug

**Notes**

Setting `xdebug.remote_connect_back` does not work when xDebug is inside a Docker container. using the `xdebug.remote_host` works fine. 

Currently using this on phpStorm. 

Can you please check I haven't done anything dumb? 

