### PR TITLE
Add cacheable dependency to response

### DIFF
--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/ContentResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/ContentResource.php
@@ -118,7 +118,9 @@ class ContentResource extends ResourceBase
         self::checkContentIdParameterIsNumeric();
         $content = $this->contentApiClass->ContentApiEndpoint($lang, $this->nid);
         if (!empty($content)) {
-            return new ResourceResponse($content);
+            $response = new ResourceResponse($content);
+            $response->addCacheableDependency($content);
+            return $response;
         }
         throw new NotFoundHttpException(t('No content found'));
     }

--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/FeaturedContentResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/FeaturedContentResource.php
@@ -90,7 +90,7 @@ class FeaturedContentResource extends ResourceBase
         LoggerInterface $logger,
         FeaturedContentApiClass $FeaturedContentApiClass,
         Request $currentRequest,
-        LanguageManager $languageManager,
+        LanguageManager $languageManager
     ) {        
         $this->featuredContentApiClass = $FeaturedContentApiClass;
         $this->currentRequest = $currentRequest;
@@ -119,7 +119,7 @@ class FeaturedContentResource extends ResourceBase
             $container->get('logger.factory')->get('rest'),
             $container->get('moj_resources.featured_content_api_class'),
             $container->get('request_stack')->getCurrentRequest(),
-            $container->get('language_manager'),
+            $container->get('language_manager')
         );
     }   
 

--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/FeaturedContentResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/FeaturedContentResource.php
@@ -16,7 +16,6 @@ use Drupal\moj_resources\FeaturedContentApiClass;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Drupal\Core\PageCache\ResponsePolicy\KillSwitch;
 
 /**
  * @SWG\Get(
@@ -77,8 +76,6 @@ class FeaturedContentResource extends ResourceBase
 
     protected $languageManager;
 
-    protected $killSwitch;
-
     protected $paramater_category;
 
     Protected $paramater_language_tag;
@@ -94,12 +91,10 @@ class FeaturedContentResource extends ResourceBase
         FeaturedContentApiClass $FeaturedContentApiClass,
         Request $currentRequest,
         LanguageManager $languageManager,
-        KillSwitch $killSwitch
     ) {        
         $this->featuredContentApiClass = $FeaturedContentApiClass;
         $this->currentRequest = $currentRequest;
         $this->languageManager = $languageManager;
-        $this->killSwitch = $killSwitch;
         $this->availableLangs = $this->languageManager->getLanguages();
         $this->paramater_category = self::setCategory();
         $this->paramater_number_results = self::setNumberOfResults();
@@ -125,7 +120,6 @@ class FeaturedContentResource extends ResourceBase
             $container->get('moj_resources.featured_content_api_class'),
             $container->get('request_stack')->getCurrentRequest(),
             $container->get('language_manager'),
-            $container->get('page_cache_kill_switch')
         );
     }   
 

--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/PromotedContentResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/PromotedContentResource.php
@@ -110,7 +110,9 @@ class PromotedContentResource extends ResourceBase
         $lang = $this->currentRequest->get('_lang');
         $promoted = $this->promotedContentApiClass->PromotedContentApiEndpoint($lang);
         if (!empty($promoted)) {
-            return new ResourceResponse($promoted);
+            $response = new ResourceResponse($promoted);
+            $response->addCacheableDependency($promoted);
+            return $response;
         }
         throw new NotFoundHttpException(t('No promoted content found'));
     }

--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/SeriesContentResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/SeriesContentResource.php
@@ -125,13 +125,15 @@ class SeriesContentResource extends ResourceBase
 
     public function get() 
     {
-        $featuredContent = $this->seriesContentApiClass->SeriesContentApiEndpoint(
+        $seriesContent = $this->seriesContentApiClass->SeriesContentApiEndpoint(
             $this->paramater_language_tag, 
             $this->currentRequest->get('id'), 
             $this->paramater_number_results
         );
-        if (!empty($featuredContent)) {
-            return new ResourceResponse($featuredContent);
+        if (!empty($seriesContent)) {
+            $response = new ResourceResponse($seriesContent);
+            $response->addCacheableDependency($seriesContent);
+            return $response;
         }
         throw new NotFoundHttpException(t('No featured content found'));
     }

--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/TermResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/TermResource.php
@@ -119,7 +119,9 @@ class TermResource extends ResourceBase
         self::checkTermIsNumeric();
         $content = $this->termApiClass->TermApiEndpoint($this->paramater_language_tag, $this->paramater_term_id);
         if (!empty($content)) {
-            return new ResourceResponse($content);
+            $response = new ResourceResponse($content);
+            $response->addCacheableDependency($content);
+            return $response;
         }
         throw new NotFoundHttpException(t('No term found'));
     }

--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/VocabularyResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/VocabularyResource.php
@@ -120,7 +120,9 @@ class VocabularyResource extends ResourceBase
         self::checkCatgeoryIsString();
         $content = $this->vocabularyApiClass->VocabularyApiEndpoint($this->paramater_language_tag, $this->paramater_category);
         if (!empty($content)) {
-            return new ResourceResponse($content);
+            $response = new ResourceResponse($content);
+            $response->addCacheableDependency($content);
+            return $response;
         }
         throw new NotFoundHttpException(t('No featured content found'));
     }


### PR DESCRIPTION
Works with Drupal 8 when anonymous page caching is disabled in Drupal 8

More info:

- [https://drupal.stackexchange.com/questions/255579/d8-unable-to-set-cache-max-age-on-resourceresponse/255585](https://drupal.stackexchange.com/questions/255579/d8-unable-to-set-cache-max-age-on-resourceresponse/255585)

- [https://www.drupal.org/project/drupal/issues/2352009](https://www.drupal.org/project/drupal/issues/2352009)