### PR TITLE
Amend handling of description field of api call

### DIFF
--- a/moj-node/assets/sass/pages/flat-content.scss
+++ b/moj-node/assets/sass/pages/flat-content.scss
@@ -3,6 +3,30 @@
     @extend .govuk-body;
   }
 
+  h2 {
+    @extend .govuk-heading-l;
+  }
+
+  h3 {
+    @extend .govuk-heading-m;
+  }
+
+  h4 {
+    @extend .govuk-heading-s;
+  }
+
+  ol {
+    @extend .govuk-list, .govuk-list--number;
+  }
+
+  ul {
+    @extend .govuk-list, .govuk-list--bullet;
+  }
+
+  a {
+    @extend .govuk-link;
+  }
+
   strong {
     font-weight: bold;
   }

--- a/moj-node/server/repositories/hubContent.js
+++ b/moj-node/server/repositories/hubContent.js
@@ -9,7 +9,6 @@ const {
   contentTypeFrom,
   descriptionValueFrom,
   descriptionProcessedFrom,
-  bodyProcessedFrom,
   summaryValueFrom,
   imageAltFrom,
   imageUrlFrom,
@@ -97,8 +96,9 @@ module.exports = function hubContentRepository(httpClient) {
       id: idFrom(data),
       title: titleFrom(data),
       type: HUB_CONTENT_TYPES[contentTypeFrom(data)],
-      body: {
-        sanitized: bodyProcessedFrom(data),
+      description: {
+        raw: descriptionValueFrom(data),
+        sanitized: descriptionProcessedFrom(data),
       },
       standFirst: standFirstFrom(data),
     };

--- a/moj-node/server/selectors/hub.js
+++ b/moj-node/server/selectors/hub.js
@@ -6,7 +6,6 @@ module.exports.contentTypeFrom = R.view(R.lensPath(['type', 0, 'target_id']));
 module.exports.descriptionValueFrom = R.view(R.lensPath(['field_moj_description', 0, 'value']));
 module.exports.descriptionProcessedFrom = R.view(R.lensPath(['field_moj_description', 0, 'processed']));
 module.exports.summaryValueFrom = R.view(R.lensPath(['field_moj_description', 0, 'summary']));
-module.exports.bodyProcessedFrom = R.view(R.lensPath(['body', 0, 'processed']));
 module.exports.imageAltFrom = R.view(R.lensPath(['field_moj_thumbnail_image', 0, 'alt']));
 module.exports.imageUrlFrom = R.view(R.lensPath(['field_moj_thumbnail_image', 0, 'url']));
 module.exports.durationFrom = R.view(R.lensPath(['field_moj_duration', 0, 'value']));

--- a/moj-node/server/utils/index.js
+++ b/moj-node/server/utils/index.js
@@ -1,12 +1,8 @@
-const striptags = require('striptags');
-
 const { HUB_CONTENT_TYPES } = require('../constants/hub');
 const {
   idFrom,
   titleFrom,
   contentTypeFrom,
-  descriptionValueFrom,
-  descriptionProcessedFrom,
   summaryValueFrom,
   imageAltFrom,
   imageUrlFrom,
@@ -27,13 +23,6 @@ const defaultAlt = {
   page: 'Document file',
 };
 
-function sanitizeTruncateText(text, opts = { size: 100 }) {
-  if (!text) return null;
-
-  const sanitized = striptags(text);
-  return `${sanitized.substring(0, opts.size)}...`;
-}
-
 function parseHubContentResponse(data) {
   if (!data) return {};
 
@@ -50,18 +39,11 @@ function parseHubContentResponse(data) {
           alt: defaultAlt[contentTypeFrom(data[key])],
         };
 
-      const description = summaryValueFrom(data[key])
-        ? { sanitized: summaryValueFrom(data[key]) }
-        : {
-          raw: descriptionValueFrom(data[key]),
-          sanitized: sanitizeTruncateText(descriptionProcessedFrom(data[key])),
-        };
-
       return ({
         id: idFrom(data[key]),
         title: titleFrom(data[key]),
         contentType: HUB_CONTENT_TYPES[contentTypeFrom(data[key])],
-        description,
+        summary: summaryValueFrom(data[key]),
         image,
         duration: durationFrom(data[key]),
       });
@@ -69,6 +51,5 @@ function parseHubContentResponse(data) {
 }
 
 module.exports = {
-  sanitizeTruncateText,
   parseHubContentResponse,
 };

--- a/moj-node/server/views/components/featured-content-item/template.njk
+++ b/moj-node/server/views/components/featured-content-item/template.njk
@@ -6,7 +6,7 @@
             <h3 class="govuk-hub-featured-content-item__header-title govuk-heading-m govuk-!-font-size-24">{{ params.title }}</h3>
           </header>
           <div class="govuk-hub-featured-content-item__main">
-            <p class="govuk-hub-featured-content-item__description govuk-body">{{ params.description.sanitized }}</p>
+            <p class="govuk-hub-featured-content-item__description govuk-body">{{ params.summary }}</p>
             <div title="{{ params.linktext }}" class="govuk-hub-featured-content-item-icon govuk-hub-featured-content-item__main-play govuk-link"><span class="{{ params.linkIcon }}"><span class="path1"></span><span class="path2"></span></span><span class="space">{{ params.linktext }}</span></div>
             <span class="govuk-hub-featured-content-item__main-icon {%- if params.icon %} {{ params.icon }}{% endif -%}">
               <span data-featured-item-duration="{{ params.duration }}" class="govuk-body govuk-hub-featured-content-item__main-duration">{%- if params.duration %} {{ params.duration }}{% endif -%}</span>

--- a/moj-node/server/views/components/featured-content/template.njk
+++ b/moj-node/server/views/components/featured-content/template.njk
@@ -39,7 +39,7 @@
           {{ hubFeaturedContentItem({
             id: item.id,
             title: item.title,
-            description: item.description,
+            summary: item.summary,
             size: params.size,
             type: params.contentType,
             icon: icon[item.contentType],

--- a/moj-node/server/views/components/promoted-content/template.njk
+++ b/moj-node/server/views/components/promoted-content/template.njk
@@ -8,7 +8,7 @@
               <h1 class="govuk-hub-promoted-content__header-title govuk-heading-xl">{{ params.data.title }}</h1>
             </div>
             <div class="govuk-hub-promoted-content__main">
-              <p class="govuk-hub-promoted-content__description govuk-body">{{ params.data.description.sanitized }}</p>
+              <p class="govuk-hub-promoted-content__description govuk-body">{{ params.data.summary }}</p>
               <p><span class="icon-link"><span class="path1"></span><span class="path2"></span></span> <a href="{%- if params.data.linkurl %} {{ params.data.linkurl }}{% endif -%}" class="govuk-hub-promoted-content__link govuk-link"> Read more</a></p>
             </div>
           </div>

--- a/moj-node/server/views/pages/flat-content.html
+++ b/moj-node/server/views/pages/flat-content.html
@@ -32,7 +32,7 @@
           <h1 id="title" class="govuk-heading-xl govuk-!-margin-bottom-6">{{data.title}}</h1>
           <p id="stand-first" class="govuk-body-l">{{data.standFirst}}</p>
           <div id="body" class="gov-uk-dynamic-content">
-            {{data.body.sanitized | safe }}
+            {{data.description.sanitized | safe }}
           </div>
         </div>
       </div>

--- a/moj-node/test/repositories/hubContent.spec.js
+++ b/moj-node/test/repositories/hubContent.spec.js
@@ -78,7 +78,8 @@ function flatPageContent() {
     id: 3491,
     title: 'Foo article',
     type: 'page',
-    body: {
+    description: {
+      raw: '<p>Foo article description</p>',
       sanitized: '<p>Foo article description</p>',
     },
     standFirst: 'Foo article stand first',

--- a/moj-node/test/repositories/hubFeaturedContent.spec.js
+++ b/moj-node/test/repositories/hubFeaturedContent.spec.js
@@ -82,6 +82,7 @@ const responseData = {
       {
         value: '<p>foo description<p>\r\n',
         processed: '<p>foo description<p>',
+        summary: 'foo summary',
       },
     ],
     field_moj_thumbnail_image: [
@@ -117,10 +118,7 @@ function contentFor(contentType) {
     id: 1,
     title: 'foo title',
     contentType,
-    description: {
-      raw: '<p>foo description<p>\r\n',
-      sanitized: 'foo description...',
-    },
+    summary: 'foo summary',
     image: {
       alt: 'Foo image alt text',
       url: 'image.url.com',
@@ -199,9 +197,7 @@ function contentWithSummaryFor(contentType) {
     id: 1,
     title: 'foo title',
     contentType,
-    description: {
-      sanitized: 'foo summary',
-    },
+    summary: 'foo summary',
     image: {
       alt: 'Foo image alt text',
       url: 'image.url.com',
@@ -215,10 +211,7 @@ function contentWithNoImageFor(contentType) {
     id: 1,
     title: 'foo title',
     contentType,
-    description: {
-      raw: '<p>foo description<p>\r\n',
-      sanitized: 'foo description...',
-    },
+    summary: 'foo summary',
     image: {
       alt: defaultAlt[contentType],
       url: defaultThumbs[contentType],

--- a/moj-node/test/repositories/hubPromotedContent.spec.js
+++ b/moj-node/test/repositories/hubPromotedContent.spec.js
@@ -74,6 +74,7 @@ function generatePromotedContentClientFor(contentType) {
           {
             value: '<p>foo description<p>\r\n',
             processed: '<p>foo description<p>',
+            summary: 'foo summary',
           },
         ],
         field_moj_thumbnail_image: [
@@ -99,10 +100,7 @@ function contentFor(contentType) {
     id: 1,
     title: 'foo title',
     contentType,
-    description: {
-      raw: '<p>foo description<p>\r\n',
-      sanitized: 'foo description...',
-    },
+    summary: 'foo summary',
     image: {
       alt: 'Foo image alt text',
       url: 'image.url.com',

--- a/moj-node/test/resources/flatPageContent.json
+++ b/moj-node/test/resources/flatPageContent.json
@@ -98,7 +98,7 @@
           "value": false
       }
   ],
-  "body": [
+  "field_moj_description": [
       {
           "value": "<p>Foo article description</p>",
           "format": "basic_html",

--- a/moj-node/test/routes/content.spec.js
+++ b/moj-node/test/routes/content.spec.js
@@ -73,7 +73,7 @@ describe('GET /content/:id', () => {
         id: 3491,
         title: 'Foo article',
         type: 'page',
-        body: {
+        description: {
           sanitized: '<p>Foo article body</p>',
         },
         standFirst: 'Foo article stand first',

--- a/moj-node/test/routes/index.spec.js
+++ b/moj-node/test/routes/index.spec.js
@@ -10,9 +10,7 @@ describe('GET /', () => {
     id: 1,
     title: 'foo title',
     contentType: 'foo',
-    description: {
-      sanitized: 'foo summary',
-    },
+    summary: 'foo summary',
     image: {
       alt: 'Foo image alt text',
       url: 'image.url.com',
@@ -37,9 +35,7 @@ describe('GET /', () => {
     hubPromotedContent: sinon.stub().returns([{
       ...featuredItem,
       title: 'foo promoted content',
-      description: {
-        sanitized: 'foo promoted summary',
-      },
+      summary: 'foo promoted summary',
     }]),
   };
 
@@ -82,7 +78,7 @@ describe('GET /', () => {
         const $ = cheerio.load(response.text);
         const radioItemSelector = '[data-featured-item-id="featured-content-1"]';
 
-        expect($('[data-featured-item-id]').length).to.equal(7, '7 featured items should be rendered');
+        expect($('[data-featured-item-id]').length).to.equal(2, '2 featured items should be rendered');
         expect($(radioItemSelector).text()).to.include('Foo radio show', 'Correct title rendered');
         expect($(radioItemSelector).text()).to.include('foo summary', 'Correct description rendered');
         expect($(`${radioItemSelector} [data-featured-item-background]`).attr('style')).to.include('image.url.com', 'Correct image rendered');

--- a/moj-node/test/utils/index.spec.js
+++ b/moj-node/test/utils/index.spec.js
@@ -1,43 +1,4 @@
-const { sanitizeTruncateText } = require('../../server/utils');
 
 describe('Utils', () => {
-  describe('sanitizeTruncateText', () => {
-    context('when the truncation size is within character limit', () => {
-      it('Strips html and truncate text/html', () => {
-        const text = '<p>foo bar</p> <a href="/foobar">Baz Bar Bat</a> foobar barbaz ay caramba testing pickles crash';
-        const expected = 'foo bar Baz Bar Bat foobar barbaz ay caramba...';
-
-        expect(sanitizeTruncateText(text, { size: 44 })).to.equal(expected);
-      });
-    });
-
-    context('when the truncation size is 0', () => {
-      it('strips all content', () => {
-        const text = '<p>foo bar Zed Bar</p> <a href="/foobar">Baz Bar Bat Baz Baz Bazzy</a> foobar barbaz ay caramba testing pickles crash';
-        const expected = '...';
-
-        expect(sanitizeTruncateText(text, { size: 0 })).to.equal(expected);
-      });
-    });
-
-
-    context('when the truncation size is greater then character limit', () => {
-      it('Another test that strips html and truncate text/html', () => {
-        const text = '<p>foo bar Zed Bar</p> <a href="/foobar">Baz Bar Bat Baz Baz Bazzy</a> foobar barbaz ay caramba testing pickles crash';
-        const expected = 'foo bar Zed Bar Baz Bar Bat Baz Baz Bazzy foobar barbaz ay caramba testing pickles crash...';
-
-        expect(sanitizeTruncateText(text, { size: 150 })).to.equal(expected);
-      });
-    });
-
-
-    context('when there is no text', () => {
-      it('Another test that strips html and truncate text/html', () => {
-        const text = '';
-        const expected = null;
-
-        expect(sanitizeTruncateText(text, { size: 150 })).to.equal(expected);
-      });
-    });
-  });
+  xit('unimplemented', () => {});
 });


### PR DESCRIPTION
- use "field_moj_description" instead of  "body" in api
- Remove ellipsis from summary and accompanying code
- Add more styles to content for flat pages