### PR TITLE
Adjust for python2/python3 differences

### DIFF
--- a/ansible/roles/letsencrypt/tasks/main.yml
+++ b/ansible/roles/letsencrypt/tasks/main.yml
@@ -14,7 +14,7 @@
   copy:
     dest: /etc/letsencrypt/cli.ini
     content: |
-      {% for k, v in certbot_options.iteritems() %}
+      {% for k, v in certbot_options.items() %}
       {{ k }}={{ v }}
       {% endfor %}
   vars:


### PR DESCRIPTION
Adjusted to account for the differences between executing ansible with python2 vs python3.  In python3 dict.iteritems has been removed.

Have tested with Ansible 2.6.1 and python 2.7.14 & 3.6.5