### PR TITLE
Increasing default client max body size

### DIFF
--- a/ansible/roles/hub-containers/tasks/nginx.yml
+++ b/ansible/roles/hub-containers/tasks/nginx.yml
@@ -1,4 +1,5 @@
 - set_fact:
+    nginx_client_max_body_size: 1024m
     hub_nginx_upstream:
       name: "{{ hub_site.upstream_name }}"
       servers:


### PR DESCRIPTION
Required to match manual changes that had been made in the environment some time ago.