### PR TITLE
Update Matomo `docker-compose` config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ services:
                         - hub-matomo-db
                 volumes:
                         - ./moj-reporting/config:/var/www/html/config:rw
+                        - ./moj-reporting/digital-hub-matmomo-db/var/lib/mysql/data:/var/lib/mysql/data
                         - ./logs:/var/www/html/logs
         hub-matomo-db:
                 image: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,13 +121,16 @@ services:
                 depends_on:
                         - hub-matomo-db
                 ports:
-                        - 12002
+                        - 8185:80
+                links:
+                        - hub-matomo-db
+                volumes:
+                        - ./moj-reporting/config:/var/www/html/config:rw
+                        - ./logs:/var/www/html/logs
         hub-matomo-db:
-                image: mojdigitalstudio/digital-hub-matomo-db
+                image: mariadb
                 environment:
-                        MYSQL_ROOT_PASSWORD: rootpass
-                        MYSQL_DATABASE: matomo_db
+                        MYSQL_ROOT_PASSWORD: password
+                        MYSQL_DATABASE: matomo
                         MYSQL_USER: matomo_user
                         MYSQL_PASSWORD: matomo_pass
-                volumes:
-                        - /data/digital-hub-matmomo-db/var/lib/mysql/data:/var/lib/mysql/data

--- a/moj-node/server/views/components/template.njk
+++ b/moj-node/server/views/components/template.njk
@@ -15,6 +15,21 @@
 
     {# The default og:image is added below head so that scrapers see any custom metatags first, and this is just a fallback #}
     <meta property="og:image" content="{{ assetPath | default('/assets') }}/images/govuk-opengraph-image.png">
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//{{envVars.MATOMO_URL}}/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '1']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
   </head>
   <body class="govuk-template__body {{ bodyClasses }}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
@@ -71,21 +86,5 @@
 
     {% block bodyEnd %}{% endblock %}
     <script src="/public/javascript/hub.js"></script>
-
-    <!-- Matomo -->
-    <script type="text/javascript">
-      var _paq = _paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u="//{{envVars.MATOMO_URL}}/";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
-        _paq.push(['setSiteId', '1']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-      })();
-    </script>
-    <!-- End Matomo Code -->
   </body>
 </html>


### PR DESCRIPTION
- Update docker-compose file so Matomo reporting works
- Update local folder names so they conform with current naming conventions
- Update local port numbers so they conform with current naming conventions
- Add a link from `Matomo` app to `MariaDB` database

This will spin up an instance of Matomo but will still need to run the setup wizard.

We can replace the MariaDB with a custom docker image, like the current hub to have something that just works on `docker-compose up`

Steps:

- Create a custom DB image with the same setup/spec as the current hub cms `db`
- Commit `config.ini.php` with settings to get up:
```
[database]
host = "hub-matomo-db"
username = "user123"
password = "pass123"
dbname = "matomodb"

[General]
trusted_hosts[] = "localhost:123"
```
- Add tracking script to node app 
