### PR TITLE
Add ordering by weight to featured content

### DIFF
--- a/moj-be/modules/custom/moj_resources/src/FeaturedContentApiClass.php
+++ b/moj-be/modules/custom/moj_resources/src/FeaturedContentApiClass.php
@@ -67,6 +67,7 @@ class FeaturedContentApiClass
         $this->lang = $lang;
         $this->nids = self::getFeaturedContentNodeIds($category, $number);
         $this->nodes = self::loadNodesDetails($this->nids);
+        usort($this->nodes, 'self::sortByWeight');
         return array_map('self::translateNode', $this->nodes);
         // return array_map('self::serialize', $translatedNodes);
     }
@@ -97,8 +98,6 @@ class FeaturedContentApiClass
         if ($category !== 0) {
             $results->condition('field_moj_top_level_categories', $category);
         };
-
-        $results->sort('changed', 'DESC');
         
         return $results->execute();
     }
@@ -116,6 +115,14 @@ class FeaturedContentApiClass
                 return $item->access();
             }
         );
+    }
+    /**
+     * sortByWeight
+     *
+     */
+    protected function sortByWeight($a, $b)
+    {
+        return (int)$a->field_moj_weight->value > (int)$b->field_moj_weight->value;
     }
     /**
      * Sanitise node


### PR DESCRIPTION
- Orders the array of returned node objects by the `field_moj_weight` value.
- Using a custom sort function as Drupal's entity manager sort function seems to be ignored.