### PR TITLE
Add OR condition group to related content API

### DIFF
--- a/moj-be/modules/custom/moj_resources/src/RelatedContentApiClass.php
+++ b/moj-be/modules/custom/moj_resources/src/RelatedContentApiClass.php
@@ -94,7 +94,11 @@ class RelatedContentApiClass
             ->accessCheck(false);
 
         if ($category !== 0) {
-            $results->condition('field_moj_top_level_categories', $category);
+            $group = $results
+                ->orConditionGroup()
+                ->condition('field_moj_top_level_categories', $category)
+                ->condition('field_moj_tags', $category);
+            $results->condition($group);
         };
         return $results->execute();
     }


### PR DESCRIPTION
Add an OR condition group to the related content API call to search using the primary OR secondary tags.