### PR TITLE
Add cacheable dependency to the menu resource endpoint

### DIFF
--- a/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/MenuResource.php
+++ b/moj-be/modules/custom/moj_resources/src/Plugin/rest/resource/MenuResource.php
@@ -124,7 +124,10 @@ class MenuResource extends ResourceBase
             $this->paramater_current_page_id
         );
         if (!empty($menu)) {
-            return new ResourceResponse($menu);
+
+            $response = new ResourceResponse($menu);
+            $response->addCacheableDependency($menu);
+            return $response;
         }
         throw new NotFoundHttpException(t('No featured content found'));
     }


### PR DESCRIPTION
There was an issue with caching which is why the `_parent` parameter wasn't working. I've added a cachable dependency to the menu resource to fix it. 