### PR TITLE
Fix offset for related content

### DIFF
--- a/moj-node/assets/javascript/tags.js
+++ b/moj-node/assets/javascript/tags.js
@@ -6,8 +6,8 @@
 
   var url = "/tags/related-content/" + contentId;
   var customTags = [ '<%', '%>' ];
-  var currentOffset = 9;
-  var paginateOffset = 9
+  var currentOffset = 8;
+  var paginateOffset = 8;
 
 
   // Mustache stuff;

--- a/moj-node/server/repositories/hubContent.js
+++ b/moj-node/server/repositories/hubContent.js
@@ -54,7 +54,7 @@ module.exports = function hubContentRepository(httpClient) {
     return parseHubContentResponse(response);
   }
 
-  async function relatedContentFor({ id, perPage = 8, offset = 1 }) {
+  async function relatedContentFor({ id, perPage = 8, offset = 0 }) {
     const response = await httpClient.get(`${config.api.hubContent}/related`, {
       _category: id,
       _number: perPage,

--- a/moj-node/server/routes/tags.js
+++ b/moj-node/server/routes/tags.js
@@ -33,7 +33,6 @@ module.exports = function Tags({
   router.get('/related-content/:id', async (req, res) => {
     try {
       logger.info(`GET /tags/${req.params.id}/related-content`);
-
       const data = await hubTagsService.relatedContentFor({ id: req.params.id, ...req.query });
       res.json(data);
     } catch (exp) {


### PR DESCRIPTION
The Drupal api uses a 0 based offset. We had set the offset to 1 so we were always missing one item from the dataset in both the lazy load and server rendered related content