### PR TITLE
Refactor for wayland deployment

### DIFF
--- a/moj-fe/Dockerfile
+++ b/moj-fe/Dockerfile
@@ -22,6 +22,6 @@ COPY --from=node /node /app
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY fpm.conf /usr/local/etc/php-fpm.d/www.conf
-RUN chown -R www-data: /app
+RUN chown -R www-data:www-data /app
 CMD ["/usr/bin/supervisord"]
 EXPOSE 80/tcp

--- a/moj-fe/supervisord.conf
+++ b/moj-fe/supervisord.conf
@@ -12,9 +12,10 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=API_URI=%(ENV_API_URI),APP_TIMEOUT=%(ENV_APP_TIMEOUT)
+environment=
+	API_URI=%(ENV_API_URI)s,
+	APP_TIMEOUT=60.0
 
- 
 [program:nginx]
 command=/usr/sbin/nginx -g 'daemon off;'
 autostart=true


### PR DESCRIPTION
This change is to shift wayland's frontend containers to use nginx+fpm rather than apache+mod_php. It was the result of hard to identify client side issues approximately the size and dimensions of a nut, and this is our sledgehammer. 