### PR TITLE
Attempt at preventing docker pull hangs at boot

### DIFF
--- a/ansible/roles/jenkins/templates/systemd.jenkinsstack.service.j2
+++ b/ansible/roles/jenkins/templates/systemd.jenkinsstack.service.j2
@@ -3,10 +3,13 @@ Description="Jenkins stack managed by docker-compose"
 After=docker.service
 Requires=docker.service
 
+# Note that we've put a timeout of 10 minutes in below against the docker pull as
+# it's been seen to hang indefinitely in the past, preventing Jenkins from starting.
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/usr/bin/docker pull {{ docker_image }}
+ExecStartPre=/usr/bin/timeout 10m /usr/bin/docker pull {{ docker_image }}
 ExecStart=/usr/bin/docker stack deploy -c /opt/docker/jenkins-stack.yml jenkins
 ExecStop=/usr/bin/docker stack rm jenkins
 ExecStopPost=/bin/sleep 10


### PR DESCRIPTION
It's been seen that the jenkinsstack service can hang at boot waiting for docker pull to complete updating images from docker hub.  The service status can be seen below.  The process itself didn't appear to have any network sockets open (based on lsof and netstat output) and strace indicates it was stuck polling a file handle (scrollback buffer lost what the file handle was sadly).  A systemd-analyze confirmed that jenkinsstack started after the network, so everything should have been fine.  The quick fix (hopefully) is to enforce a timeout on just the docker pull.

```
# systemctl status jenkinsstack
● jenkinsstack.service - "Jenkins stack managed by docker-compose"
   Loaded: loaded (/etc/systemd/system/jenkinsstack.service; enabled; vendor preset: enabled)
   Active: activating (start-pre) since Tue 2019-05-14 02:01:07 UTC; 11h ago
  Control: 1260 (docker)
    Tasks: 6
   Memory: 40.9M
      CPU: 1.137s
   CGroup: /system.slice/jenkinsstack.service
           └─control
             └─1260 /usr/bin/docker pull mojdigitalstudio/digital-studio-platform-jenkins:latest

May 14 02:01:07 hub-bounce-prod systemd[1]: Starting "Jenkins stack managed by docker-compose"...
```