### PR TITLE
Make header tags semantically correct and find a real H1

### DIFF
--- a/moj-node/assets/sass/components/_header.scss
+++ b/moj-node/assets/sass/components/_header.scss
@@ -147,16 +147,20 @@
   left: 0;
 }
 
-.hub-header-user-container span {
+.hub-header-user-container span,
+.hub-header-user-container h1 {
   border-right: 1px solid govuk-colour('white');
   margin-right: govuk-spacing(1);
 }
 
-.hub-header-user-container span:first-child {
+.hub-header-user-container span {
   padding-right: govuk-spacing(2);
 }
 
-.hub-header-user-container span:last-child {
+.hub-header-user-container h1 {
   border: none;
-  margin-right: 0;
+  margin: 0;
+  font-weight: 400;
+  display: inline-block;
+  font-size: 1rem;
 }

--- a/moj-node/assets/sass/components/_promoted-content.scss
+++ b/moj-node/assets/sass/components/_promoted-content.scss
@@ -89,7 +89,7 @@ $gradient: $trans, $seventyFivePercentBlack;
 .govuk-hub-promoted-content__no-link {
   text-decoration: none;
 
-  h1 {
+  h2 {
     text-decoration: none;
     color: #005ea5;
   }

--- a/moj-node/server/views/components/featured-content/template.njk
+++ b/moj-node/server/views/components/featured-content/template.njk
@@ -4,9 +4,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if params.categoryLink %}
-        <a class="govuk-hub-no-link" href="{{ params.categoryLink }}"><h1 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title">{{ params.categoryTitle }}</h1></a>
+        <h2 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title"><a class="govuk-hub-no-link" href="{{ params.categoryLink }}">{{ params.categoryTitle }}</a></h2>
       {% else %}
-        <h1 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title">{{ params.categoryTitle }}</h1>
+        <h2 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title">{{ params.categoryTitle }}</h2>
       {% endif %}
     </div>
     <div class="govuk-grid-column-one-third govuk-hub-align-right">

--- a/moj-node/server/views/components/header/template.njk
+++ b/moj-node/server/views/components/header/template.njk
@@ -6,7 +6,7 @@
         {% if params.user %}
           <div id="hub-auth-header" class="hub-header-user-container">
             <span class="govuk-!-font-weight-bold">{{ params.user.name }}</span>
-            <span>{{ params.appName }}</span>
+            <h1>{{ params.appName }}</h1>
           </div>
         {% else %}
           <a href="/" class="govuk-hub-header__link govuk-hub-header__link--homepage">

--- a/moj-node/server/views/components/promoted-content/template.njk
+++ b/moj-node/server/views/components/promoted-content/template.njk
@@ -40,7 +40,7 @@
 
             <div class="govuk-hub-promoted-content-container">
               <div class="govuk-hub-promoted-content__header">
-                <h1 class="govuk-hub-promoted-content__header-title govuk-heading-m">{{ params.data.title }}</h1>
+                <h2 class="govuk-hub-promoted-content__header-title govuk-heading-m">{{ params.data.title }}</h2>
               </div>
               <div class="govuk-hub-promoted-content__main">
                 <p class="govuk-hub-promoted-content__description govuk-body">{{ params.data.summary }}</p>

--- a/moj-node/server/views/components/topics/template.njk
+++ b/moj-node/server/views/components/topics/template.njk
@@ -1,7 +1,7 @@
 <section>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Browse by topic</h1>
+      <h2 class="govuk-heading-l govuk-!-margin-bottom-2">Browse by topic</h2>
     </div>
   </div>
   <div class="govuk-grid-row">

--- a/moj-node/server/views/pages/index.html
+++ b/moj-node/server/views/pages/index.html
@@ -86,7 +86,7 @@
   <nav id="homepage-navigation" class="govuk-hub-main_navigation_banner">
     <ul class="govuk-hub-main_navigation">
       <li class="govuk-hub-main_navigation_current_page">
-        <span class="govuk-link" >Home<span/>
+        <span class="govuk-link">Home</span>
       </li>
       {%  for menuItem in homepageMenu %}
         <li>

--- a/moj-node/test/routes/index.spec.js
+++ b/moj-node/test/routes/index.spec.js
@@ -232,7 +232,7 @@ describe('GET /', () => {
         .then(response => {
           const $ = cheerio.load(response.text);
 
-          expect($('#browser-by-topic h1').text()).to.equal('Browse by topic');
+          expect($('#browser-by-topic h2').text()).to.equal('Browse by topic');
           expect($('#browser-by-topic .govuk-hub-topics li').length).to.equal(
             2,
             'Correct number of menu items',
@@ -428,7 +428,7 @@ describe('GET /', () => {
         .then(response => {
           const $ = cheerio.load(response.text);
 
-          expect($('#browser-by-topic h1').text()).to.equal('Browse by topic');
+          expect($('#browser-by-topic h2').text()).to.equal('Browse by topic');
           expect($('#browser-by-topic .govuk-hub-topics li').length).to.equal(
             2,
             'Correct number of menu items',


### PR DESCRIPTION
Due to accessibility needs, the headings have been sorted out

- Redo all H1s to H2s on main page
- Adjust CSS as required
- Use prison name as H1