### PR TITLE
Fix focus states for links

### DIFF
--- a/moj-node/assets/sass/components/_featured-content-item.scss
+++ b/moj-node/assets/sass/components/_featured-content-item.scss
@@ -4,6 +4,15 @@ $fortyPercentBlack: rgba(0, 0, 0, 0.4);
 $gradient: $trans, $seventyFivePercentBlack;
 $hub-grey: #494c4e;
 $mauve: #6f72af;
+@mixin featured-content-item-scale-shadow {
+  -webkit-transform: scale(1.1);
+  -ms-transform: scale(1.1);
+  transform: scale(1.1);
+  z-index: 100;
+  -webkit-box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.75);
+  -moz-box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.75);
+  box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.75);
+}
 
 .govuk-hub-featured-content-item__overlay,
 .govuk-hub-featured-content-item__image {
@@ -31,26 +40,38 @@ $mauve: #6f72af;
   &.large {
     height: 380px;
   }
-  &:hover {
-    -webkit-transform: scale(1.1);
-    -ms-transform: scale(1.1);
-    transform: scale(1.1);
-    z-index: 100;
-    -webkit-box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.75);
-    -moz-box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.75);
-    box-shadow: 0px 0px 20px 5px rgba(0, 0, 0, 0.75);
+}
 
-    .govuk-hub-featured-content-item__overlay {
-      background: $seventyFivePercentBlack;
-    }
-    .govuk-hub-featured-content-item__header {
-      opacity: 0;
-    }
+.govuk-hub-featured-content-item:hover,
+.govuk-hub-featured-link:focus .govuk-hub-featured-content-item {
+  @include featured-content-item-scale-shadow;
+}
 
-    .govuk-hub-featured-content-item__main {
-      opacity: 1;
-    }
-  }
+.govuk-hub-featured-content-item:hover
+  .govuk-hub-featured-content-item__overlay,
+.govuk-hub-featured-link:focus
+  .govuk-hub-featured-content-item
+  .govuk-hub-featured-content-item__overlay {
+  background: $seventyFivePercentBlack;
+}
+
+.govuk-hub-featured-content-item:hover .govuk-hub-featured-content-item__header,
+.govuk-hub-featured-link:focus
+  .govuk-hub-featured-content-item
+  .govuk-hub-featured-content-item__header {
+  opacity: 0;
+}
+
+.govuk-hub-featured-content-item:hover .govuk-hub-featured-content-item__main,
+.govuk-hub-featured-link:focus
+  .govuk-hub-featured-content-item
+  .govuk-hub-featured-content-item__main {
+  opacity: 1;
+}
+.govuk-hub-featured-link:focus
+  .govuk-hub-featured-content-item
+  .govuk-hub-featured-content-item__main {
+  border: 3px solid govuk-colour('yellow');
 }
 
 .govuk-hub-featured-content-item__header,
@@ -79,6 +100,7 @@ $mauve: #6f72af;
   margin-left: govuk-spacing(1);
   display: inline-block;
   text-decoration: underline;
+  color: govuk-colour('white');
 }
 
 .govuk-hub-featured-content-item__main-play {

--- a/moj-node/assets/sass/components/_featured-content.scss
+++ b/moj-node/assets/sass/components/_featured-content.scss
@@ -14,6 +14,11 @@
   font-weight: bold;
 }
 
+.govuk-hub-featured-content__category-title .govuk-link {
+  color: govuk-colour('white');
+  text-decoration: none;
+}
+
 .govuk-hub-featured-content__category-link {
   @include govuk-font($size: 24);
   display: inline-block;
@@ -40,6 +45,7 @@
 
 .govuk-hub-featured-link {
   color: govuk-colour('white');
+  display: block;
 }
 
 .content-items {

--- a/moj-node/assets/sass/components/_promoted-content.scss
+++ b/moj-node/assets/sass/components/_promoted-content.scss
@@ -3,10 +3,14 @@ $seventyFivePercentBlack: rgba(0, 0, 0, 0.75);
 
 $gradient: $trans, $seventyFivePercentBlack;
 
+.govuk-hub-promoted-content-link-wrapper {
+  display: block;
+  padding: 20px;
+  background: govuk-colour('grey-3');
+}
+
 .govuk-hub-promoted-content {
   position: relative;
-  border: solid govuk-colour('grey-3') 20px;
-  background: govuk-colour('grey-3');
 }
 
 .govuk-hub-promoted-content::after {

--- a/moj-node/assets/sass/components/_topics.scss
+++ b/moj-node/assets/sass/components/_topics.scss
@@ -13,8 +13,6 @@
       a {
         display: inline-block;
         @include govuk-font($size: 19);
-        color: white !important;
-        background-color: #005ea5;
         padding: 5px 5px 2px 5px;
         text-decoration: none;
         font-weight: 700;

--- a/moj-node/server/views/components/featured-content-item/template.njk
+++ b/moj-node/server/views/components/featured-content-item/template.njk
@@ -31,7 +31,7 @@
   game: "icon-link"
 }%}
 
-<a data-featured-id="{{ params.id }}" class="govuk-hub-featured-link" href="{{ params.contentUrl }}" {% if params.contentType === 'pdf' %} target="_blank" {% endif %}>
+<a data-featured-id="{{ params.id }}" class="govuk-link govuk-hub-featured-link" href="{{ params.contentUrl }}" {% if params.contentType === 'pdf' %} target="_blank" {% endif %}>
   <article class="govuk-hub-featured-content-item {{ params.size }}">
       <div data-featured-item-background class="govuk-hub-featured-content-item__image" style="background-image:url({{ params.graphic.url }})">
         <div class="govuk-hub-featured-content-item__overlay">

--- a/moj-node/server/views/components/featured-content/template.njk
+++ b/moj-node/server/views/components/featured-content/template.njk
@@ -4,7 +4,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if params.categoryLink %}
-        <h2 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title"><a class="govuk-hub-no-link" href="{{ params.categoryLink }}">{{ params.categoryTitle }}</a></h2>
+        <h2 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title"><a class="govuk-link govuk-hub-no-link" href="{{ params.categoryLink }}">{{ params.categoryTitle }}</a></h2>
       {% else %}
         <h2 data-featured-section-title="{{ params.categoryTitle }}" class="govuk-hub-featured-content__category-title">{{ params.categoryTitle }}</h2>
       {% endif %}

--- a/moj-node/server/views/components/promoted-content/template.njk
+++ b/moj-node/server/views/components/promoted-content/template.njk
@@ -31,7 +31,7 @@
 <article data-promoted-item-text class="">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <a data-content-type="{{params.data.contentType}}" data-call-to-action="read-more" class="govuk-hub-promoted-content__no-link" href="{{params.data.contentUrl}}">
+      <a data-content-type="{{params.data.contentType}}" data-call-to-action="read-more" class="govuk-link govuk-link--no-visited-state govuk-hub-promoted-content-link-wrapper govuk-hub-promoted-content__no-link" href="{{params.data.contentUrl}}">
         <div class="govuk-hub-promoted-content">
           <div class="govuk-hub-promoted-content-row">
             <div class="govuk-hub-promoted-content-image-container">


### PR DESCRIPTION
Some links on the site are not using the gps standard focus states for tabbed nav

- Made all link focus states use the govuk yellow