### PR TITLE
Change API endpoint and names accordingly

### DIFF
--- a/moj-node/assets/sass/pages/offender-profile.scss
+++ b/moj-node/assets/sass/pages/offender-profile.scss
@@ -18,33 +18,33 @@
   display: none;
 }
 
-.activities {
+.events {
   display: flex;
   align-items: stretch;
   margin-bottom: govuk-spacing(6);
 }
 
-.activities .govuk-body {
+.events .govuk-body {
   color: govuk-colour('black');
 }
 
-.activities__timePeriod {
+.events__timePeriod {
   padding: govuk-spacing(4);
   min-height: 135px;
 }
 
-.activities__timePeriod--morning {
+.events__timePeriod--morning {
   background-color: #e9f3fa;
 }
 
-.activities__timePeriod--afternoon {
+.events__timePeriod--afternoon {
   background-color: #d7e9f4;
 }
 
-.activities__timePeriod--evening {
+.events__timePeriod--evening {
   background-color: #c1ddf0;
 }
 
-.activities__timePeriod > .govuk-body:last-of-type {
+.events__timePeriod > .govuk-body:last-of-type {
   margin: 0;
 }

--- a/moj-node/server/repositories/offender.js
+++ b/moj-node/server/repositories/offender.js
@@ -41,9 +41,9 @@ function offenderRepository(httpClient) {
     );
   }
 
-  function getActivitiesForToday(bookingId) {
+  function getEventsForToday(bookingId) {
     return httpClient.get(
-      `${config.nomis.api.bookings}/${bookingId}/activities/today`,
+      `${config.nomis.api.bookings}/${bookingId}/events/today`,
     );
   }
 
@@ -55,7 +55,7 @@ function offenderRepository(httpClient) {
     getNextVisitFor,
     getLastVisitFor,
     sentenceDetailsFor,
-    getActivitiesForToday,
+    getEventsForToday,
   };
 }
 

--- a/moj-node/server/routes/index.js
+++ b/moj-node/server/routes/index.js
@@ -23,13 +23,13 @@ module.exports = function Index({
         promotionalContent,
         tagsMenu,
         homepageMenu,
-        todaysActivities,
+        todaysEvents,
       ] = await Promise.all([
         hubFeaturedContentService.hubFeaturedContent({ establishmentId }),
         hubPromotedContentService.hubPromotedContent({ establishmentId }),
         hubMenuService.tagsMenu(),
         hubMenuService.homepageMenu(establishmentId),
-        offenderService.getActivitiesForToday(bookingId),
+        offenderService.getEventsForToday(bookingId),
       ]);
 
       const config = {
@@ -44,7 +44,7 @@ module.exports = function Index({
         tagsMenu,
         homepageMenu,
         config,
-        todaysActivities,
+        todaysEvents,
       });
     } catch (exception) {
       next(exception);

--- a/moj-node/server/routes/me.js
+++ b/moj-node/server/routes/me.js
@@ -28,14 +28,14 @@ module.exports = function createMeRouter({ logger, offenderService }) {
         keyWorker,
         visits,
         importantDates,
-        todaysActivities,
+        todaysEvents,
       ] = await Promise.all([
         offenderService.getIEPSummaryFor(bookingId),
         offenderService.getBalancesFor(bookingId),
         offenderService.getKeyWorkerFor(offenderNo),
         offenderService.getVisitsFor(bookingId),
         offenderService.getImportantDatesFor(bookingId),
-        offenderService.getActivitiesForToday(bookingId),
+        offenderService.getEventsForToday(bookingId),
       ]);
 
       return res.render('pages/me', {
@@ -46,7 +46,7 @@ module.exports = function createMeRouter({ logger, offenderService }) {
           keyWorker,
           visits,
           importantDates,
-          todaysActivities,
+          todaysEvents,
         },
         config,
         today,

--- a/moj-node/server/services/offender.js
+++ b/moj-node/server/services/offender.js
@@ -46,19 +46,19 @@ const capitalize = (str = '') => {
     .join('');
 };
 
-const getActivitiesForTimeOfDay = (activities, timeOfDay) => {
-  return activities
-    .filter(activity => {
-      const activityTimeOfDay = getTimeOfDay(prop('startTime', activity));
+const getEventsForTimeOfDay = (events, timeOfDay) => {
+  return events
+    .filter(event => {
+      const eventTimeOfDay = getTimeOfDay(prop('startTime', event));
 
-      return activityTimeOfDay === timeOfDay;
+      return eventTimeOfDay === timeOfDay;
     })
-    .map(activity => {
-      const startTime = prettyTime(prop('startTime', activity));
-      const endTime = prettyTime(prop('endTime', activity));
+    .map(event => {
+      const startTime = prettyTime(prop('startTime', event));
+      const endTime = prettyTime(prop('endTime', event));
 
       return {
-        title: activity.eventSourceDesc,
+        title: event.eventSourceDesc,
         startTime,
         endTime,
         timeString: endTime === '' ? startTime : `${startTime} to ${endTime}`,
@@ -147,22 +147,22 @@ module.exports = function createOffenderService(repository) {
     };
   }
 
-  async function getActivitiesForToday(bookingId) {
-    const noActivities = {
+  async function getEventsForToday(bookingId) {
+    const noEvents = {
       morning: [],
       afternoon: [],
       evening: [],
     };
-    if (!bookingId) return noActivities;
+    if (!bookingId) return noEvents;
 
-    const activities = await repository.getActivitiesForToday(bookingId);
+    const events = await repository.getEventsForToday(bookingId);
 
-    if (!Array.isArray(activities)) return noActivities;
+    if (!Array.isArray(events)) return noEvents;
 
     return {
-      morning: getActivitiesForTimeOfDay(activities, 'morning'),
-      afternoon: getActivitiesForTimeOfDay(activities, 'afternoon'),
-      evening: getActivitiesForTimeOfDay(activities, 'evening'),
+      morning: getEventsForTimeOfDay(events, 'morning'),
+      afternoon: getEventsForTimeOfDay(events, 'afternoon'),
+      evening: getEventsForTimeOfDay(events, 'evening'),
     };
   }
 
@@ -173,6 +173,6 @@ module.exports = function createOffenderService(repository) {
     getKeyWorkerFor,
     getVisitsFor,
     getImportantDatesFor,
-    getActivitiesForToday,
+    getEventsForToday,
   };
 };

--- a/moj-node/server/views/components/template.njk
+++ b/moj-node/server/views/components/template.njk
@@ -77,7 +77,7 @@
         <div class="govuk-width-container">
           {% block beforeContent %}{% endblock %}
           {% if user %}
-            {% block todaysActivities %}{% endblock %}
+            {% block todaysEvents %}{% endblock %}
           {% endif %}
           <header class="govuk-main-wrapper" id="header-content">
             {% block promotedContent %}{% endblock %}

--- a/moj-node/server/views/pages/index.html
+++ b/moj-node/server/views/pages/index.html
@@ -26,44 +26,44 @@
   <![endif]-->
 {% endblock %}
 
-{% block todaysActivities %}
+{% block todaysEvents %}
 <h2 class="govuk-heading-l">Today</h2>
-<div class="govuk-grid-row activities">
-  <div class="govuk-grid-column-one-quarter" id="morningActivities">
-    <div class="activities__timePeriod activities__timePeriod--morning">
-    {% if todaysActivities.morning.length == 0 %}
-    <p class="govuk-body">No activities</p>
+<div class="govuk-grid-row events">
+  <div class="govuk-grid-column-one-quarter" id="morningEvents">
+    <div class="events__timePeriod events__timePeriod--morning">
+    {% if todaysEvents.morning.length == 0 %}
+    <p class="govuk-body">No events</p>
     {% endif %}
-    {% for activity in todaysActivities.morning %}
-    <p class="govuk-body">{{activity.timeString}}
-    <br><strong>{{activity.title}}</strong></p>
+    {% for event in todaysEvents.morning %}
+    <p class="govuk-body">{{event.timeString}}
+    <br><strong>{{event.title}}</strong></p>
     {% endfor %}
     </div>
   </div>
-  <div class="govuk-grid-column-one-quarter" id="afternoonActivities">
-    <div class="activities__timePeriod activities__timePeriod--afternoon">
-    {% if todaysActivities.afternoon.length == 0 %}
-    <p class="govuk-body">No activities</p>
+  <div class="govuk-grid-column-one-quarter" id="afternoonEvents">
+    <div class="events__timePeriod events__timePeriod--afternoon">
+    {% if todaysEvents.afternoon.length == 0 %}
+    <p class="govuk-body">No events</p>
     {% endif %}
-    {% for activity in todaysActivities.afternoon %}
-    <p class="govuk-body">{{activity.timeString}}
-    <br><strong>{{activity.title}}</strong></p>
+    {% for event in todaysEvents.afternoon %}
+    <p class="govuk-body">{{event.timeString}}
+    <br><strong>{{event.title}}</strong></p>
     {% endfor %}
     </div>
   </div>
-  <div class="govuk-grid-column-one-quarter" id="eveningActivities">
-    <div class="activities__timePeriod activities__timePeriod--evening">
-    {% if todaysActivities.evening.length == 0 %}
-    <p class="govuk-body">No activities</p>
+  <div class="govuk-grid-column-one-quarter" id="eveningEvents">
+    <div class="events__timePeriod events__timePeriod--evening">
+    {% if todaysEvents.evening.length == 0 %}
+    <p class="govuk-body">No events</p>
     {% endif %}
-    {% for activity in todaysActivities.evening %}
-    <p class="govuk-body">{{activity.timeString}}
-    <br><strong>{{activity.title}}</strong></p>
+    {% for event in todaysEvents.evening %}
+    <p class="govuk-body">{{event.timeString}}
+    <br><strong>{{event.title}}</strong></p>
     {% endfor %}
     </div>
   </div>
-  <div class="govuk-grid-column-one-quarter" id="otherActivities">
-    <div class="activities__timePeriod">
+  <div class="govuk-grid-column-one-quarter" id="otherEvents">
+    <div class="events__timePeriod">
       <p class="govuk-body"><a href="/" class="govuk-link">See your 7 day timetable</a></p>
     </div>
   </div>

--- a/moj-node/server/views/pages/me.html
+++ b/moj-node/server/views/pages/me.html
@@ -32,40 +32,40 @@
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">
       <h2 class="govuk-heading-l">Today, {{ today }}</h2>
-      <div class="govuk-grid-row activities">
-        <div class="govuk-grid-column-one-third" id="morningActivities">
+      <div class="govuk-grid-row events">
+        <div class="govuk-grid-column-one-third" id="morningEvents">
           <h3 class="govuk-heading-m">Morning</h3>
-          <div class="activities__timePeriod activities__timePeriod--morning">
-          {% if data.todaysActivities.morning.length == 0 %}
-          <p class="govuk-body">No activities</p>
+          <div class="events__timePeriod events__timePeriod--morning">
+          {% if data.todaysEvents.morning.length == 0 %}
+          <p class="govuk-body">No events</p>
           {% endif %}
-          {% for activity in data.todaysActivities.morning %}
-          <p class="govuk-body">{{activity.timeString}}
-          <br><strong>{{activity.title}}</strong></p>
+          {% for event in data.todaysEvents.morning %}
+          <p class="govuk-body">{{event.timeString}}
+          <br><strong>{{event.title}}</strong></p>
           {% endfor %}
           </div>
         </div>
-        <div class="govuk-grid-column-one-third" id="afternoonActivities">
+        <div class="govuk-grid-column-one-third" id="afternoonEvents">
           <h3 class="govuk-heading-m">Afternoon</h3>
-          <div class="activities__timePeriod activities__timePeriod--afternoon">
-          {% if data.todaysActivities.afternoon.length == 0 %}
-          <p class="govuk-body">No activities</p>
+          <div class="events__timePeriod events__timePeriod--afternoon">
+          {% if data.todaysEvents.afternoon.length == 0 %}
+          <p class="govuk-body">No events</p>
           {% endif %}
-          {% for activity in data.todaysActivities.afternoon %}
-          <p class="govuk-body">{{activity.timeString}}
-          <br><strong>{{activity.title}}</strong></p>
+          {% for event in data.todaysEvents.afternoon %}
+          <p class="govuk-body">{{event.timeString}}
+          <br><strong>{{event.title}}</strong></p>
           {% endfor %}
           </div>
         </div>
-        <div class="govuk-grid-column-one-third" id="eveningActivities">
+        <div class="govuk-grid-column-one-third" id="eveningEvents">
           <h3 class="govuk-heading-m">Evening</h3>
-          <div class="activities__timePeriod activities__timePeriod--evening">
-          {% if data.todaysActivities.evening.length == 0 %}
-          <p class="govuk-body">No activities</p>
+          <div class="events__timePeriod events__timePeriod--evening">
+          {% if data.todaysEvents.evening.length == 0 %}
+          <p class="govuk-body">No events</p>
           {% endif %}
-          {% for activity in data.todaysActivities.evening %}
-          <p class="govuk-body">{{activity.timeString}}
-          <br><strong>{{activity.title}}</strong></p>
+          {% for event in data.todaysEvents.evening %}
+          <p class="govuk-body">{{event.timeString}}
+          <br><strong>{{event.title}}</strong></p>
           {% endfor %}
           </div>
         </div>

--- a/moj-node/test/app.spec.js
+++ b/moj-node/test/app.spec.js
@@ -71,7 +71,7 @@ describe('App', () => {
           homepageMenu: sinon.stub(),
         },
         offenderService: {
-          getActivitiesForToday: sinon.stub(),
+          getEventsForToday: sinon.stub(),
         },
       }),
     )

--- a/moj-node/test/repositories/offenderRepository.spec.js
+++ b/moj-node/test/repositories/offenderRepository.spec.js
@@ -92,17 +92,15 @@ describe('offenderRepository', () => {
     });
   });
 
-  describe('#getActivitiesForToday', () => {
-    it('calls the getActivitiesForToday endpoint for a given ID', async () => {
+  describe('#getEventsForToday', () => {
+    it('calls the getEventsForToday endpoint for a given ID', async () => {
       const client = {
         get: sinon.stub().resolves('SOME_RESULT'),
       };
       const repository = offenderRepository(client);
-      const result = await repository.getActivitiesForToday('FOO_ID');
+      const result = await repository.getEventsForToday('FOO_ID');
 
-      expect(client.get.lastCall.args[0]).to.include(
-        '/FOO_ID/activities/today',
-      );
+      expect(client.get.lastCall.args[0]).to.include('/FOO_ID/events/today');
       expect(result).to.equal('SOME_RESULT');
     });
   });

--- a/moj-node/test/routes/index.spec.js
+++ b/moj-node/test/routes/index.spec.js
@@ -7,7 +7,7 @@ const {
   createUserSession,
 } = require('../../server/middleware/auth');
 const { setupBasicApp, logger, consoleLogError } = require('../test-helpers');
-const { getActivitiesForTodayData } = require('../test-data');
+const { getEventsForTodayData } = require('../test-data');
 
 describe('GET /', () => {
   let featuredItem;
@@ -54,9 +54,7 @@ describe('GET /', () => {
     };
 
     offenderService = {
-      getActivitiesForToday: sinon
-        .stub()
-        .returns(getActivitiesForTodayData[0].data),
+      getEventsForToday: sinon.stub().returns(getEventsForTodayData[0].data),
       getOffenderDetailsFor: sinon.stub().resolves({
         bookingId: '123456',
         offenderId: 'qwerty',
@@ -100,23 +98,23 @@ describe('GET /', () => {
       app.use(consoleLogError);
     });
 
-    it('renders todays activities', () => {
+    it('renders todays events', () => {
       return request(app)
         .get('/')
         .expect(200)
         .then(response => {
           const $ = cheerio.load(response.text);
 
-          expect($('.activities__timePeriod--morning').text()).to.include(
+          expect($('.events__timePeriod--morning').text()).to.include(
             'Some title',
             'Incorrect title rendered',
           );
-          expect($('.activities__timePeriod--afternoon').text()).to.include(
-            'No activities',
+          expect($('.events__timePeriod--afternoon').text()).to.include(
+            'No events',
             'Incorrect title rendered',
           );
-          expect($('.activities__timePeriod--evening').text()).to.include(
-            'No activities',
+          expect($('.events__timePeriod--evening').text()).to.include(
+            'No events',
             'Incorrect title rendered',
           );
         });
@@ -268,7 +266,7 @@ describe('GET /', () => {
   describe('when not authenticated', () => {
     beforeEach(() => {
       offenderService = {
-        getActivitiesForToday: sinon.stub().returns(getActivitiesForTodayData),
+        getEventsForToday: sinon.stub().returns(getEventsForTodayData),
         getOffenderDetailsFor: sinon.stub().throws(),
       };
 
@@ -304,16 +302,16 @@ describe('GET /', () => {
         });
     });
 
-    it('does not render todays activities', () => {
+    it('does not render todays events', () => {
       return request(app)
         .get('/')
         .expect(200)
         .then(response => {
           const $ = cheerio.load(response.text);
 
-          expect($('.activities').length).to.equal(
+          expect($('.events').length).to.equal(
             0,
-            "today's activities should not be displayed",
+            "today's events should not be displayed",
           );
         });
     });

--- a/moj-node/test/services/offenderService.spec.js
+++ b/moj-node/test/services/offenderService.spec.js
@@ -1,5 +1,5 @@
 const offenderService = require('../../server/services/offender');
-const { getActivitiesForTodayData } = require('../test-data');
+const { getEventsForTodayData } = require('../test-data');
 
 describe('Offender Service', () => {
   describe('.getOffenderDetailsFor', () => {
@@ -142,10 +142,10 @@ describe('Offender Service', () => {
     });
   });
 
-  describe('.getActivitiesForToday', () => {
+  describe('.getEventsForToday', () => {
     it('should call the repository service with the correct bookingId', async () => {
       const repository = {
-        getActivitiesForToday: sinon.stub().returns([
+        getEventsForToday: sinon.stub().returns([
           {
             eventSourceDesc: 'Some title',
             startTime: '2019-04-07T11:30:30',
@@ -154,20 +154,18 @@ describe('Offender Service', () => {
         ]),
       };
       const service = offenderService(repository);
-      await service.getActivitiesForToday('FOO_ID');
+      await service.getEventsForToday('FOO_ID');
 
-      expect(repository.getActivitiesForToday.lastCall.args[0]).to.equal(
-        'FOO_ID',
-      );
+      expect(repository.getEventsForToday.lastCall.args[0]).to.equal('FOO_ID');
     });
 
-    getActivitiesForTodayData.forEach(singleTestData => {
-      it(`should return activities for ${singleTestData.title}`, async () => {
+    getEventsForTodayData.forEach(singleTestData => {
+      it(`should return events for ${singleTestData.title}`, async () => {
         const repository = {
-          getActivitiesForToday: sinon.stub().returns(singleTestData.repo),
+          getEventsForToday: sinon.stub().returns(singleTestData.repo),
         };
         const service = offenderService(repository);
-        const data = await service.getActivitiesForToday('FOO_ID');
+        const data = await service.getEventsForToday('FOO_ID');
 
         expect(data).to.eql(singleTestData.data);
       });

--- a/moj-node/test/test-data.js
+++ b/moj-node/test/test-data.js
@@ -1,7 +1,7 @@
 const { format } = require('date-fns');
 
 const nowDateString = format(new Date(), 'YYYY-MM-DD');
-const getActivitiesForTodayData = [
+const getEventsForTodayData = [
   {
     title: 'single event morning',
     repo: [
@@ -137,5 +137,5 @@ const getActivitiesForTodayData = [
 ];
 
 module.exports = {
-  getActivitiesForTodayData,
+  getEventsForTodayData,
 };


### PR DESCRIPTION
Using the wrong endpoint for all events, switch to the correct one

- Use /events end point within bookings
- Update function and var names accordingly