### PR TITLE
Make sudoku game better

### DIFF
--- a/moj-node/assets/javascript/games/sudoku/sudokuJS.js
+++ b/moj-node/assets/javascript/games/sudoku/sudokuJS.js
@@ -302,7 +302,7 @@
 			var maxlength = (boardSize < 10) ? " maxlength='1'" : "";
 			return "<div class='sudoku-board-cell'>" +
 						//want to use type=number, but then have to prevent chrome scrolling and up down key behaviors..
-						"<input type='text' pattern='\\d*' novalidate id='input-"+id+"' value='"+val+"'"+maxlength+">" +
+						"<input class='govuk-input' type='text' pattern='\\d*' novalidate id='input-"+id+"' value='"+val+"'"+maxlength+">" +
 						"<div id='input-"+id+"-candidates' class='candidates'>" + candidatesString + "</div>" +
 					"</div>";
 		};

--- a/moj-node/server/views/pages/games/sudoku.html
+++ b/moj-node/server/views/pages/games/sudoku.html
@@ -47,6 +47,25 @@
           <p class="govuk-body">Sudoku is a game that involves a grid of 81 squares, divided into nine blocks, each containing nine squares.</p>
           <p class="govuk-body">Each of the nine blocks has to contain the numbers 1-9, each number can only appear once in a row, column or box. Each vertical nine-square column, or horizontal nine-square line across, within the larger square, must also contain the numbers 1-9, without repetition or omission.</p>
           <p class="govuk-body">Each sudoku puzzle has only one correct solution.</p>
+          <p class="govuk-body">Difficulty level</p>
+          <div>
+            <label for="sudoku-difficulty-easy">
+              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-easy" value="easy">
+              Easy
+            </label>
+            <label for="sudoku-difficulty-medium">
+              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-medium" value="medium">
+              Medium
+            </label>
+            <label for="sudoku-difficulty-hard">
+              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-hard" value="hard">
+              Hard
+            </label>
+            <label for="sudoku-difficulty-veryhard">
+              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-veryhard" value="very hard">
+              Very hard
+            </label>
+          </div>
           <p>
             <button id="new-game" class="govuk-button" title="Start a new game">Start a new game</button>
           </p>
@@ -70,11 +89,11 @@
   <script src="/public/javascript/games/sudoku/sudokuJS.js"></script>
   <script>
     var mySudokuJS = $("#sudoku").sudokuJS({
-      difficulty: "Easy",
+      difficulty: getLevel(),
       boardFinishedFn: function (data) {
         const message = "Congratulations \n\n You have completed the puzzle, would you like to play again?"
         if (confirm(message)) {
-          mySudokuJS.generateBoard('easy');
+          mySudokuJS.generateBoard(getLevel());
         };
       }
     });
@@ -84,8 +103,9 @@
   }, 100);*/
 
     $("#new-game").on("click", function () {
+      alert(getLevel());
       clearErrors();
-      mySudokuJS.generateBoard('easy');
+      mySudokuJS.generateBoard(getLevel());
     });
 
     function clearErrors() {
@@ -93,6 +113,9 @@
         $(this).removeAttr('disabled');
         $(this).removeClass("board-cell--error highlight-val");
       });
+    }
+    function getLevel() {
+      return $("input[name='sudoku-difficulty']:checked").val() || 'easy';
     }
   </script>
 

--- a/moj-node/server/views/pages/games/sudoku.html
+++ b/moj-node/server/views/pages/games/sudoku.html
@@ -1,5 +1,6 @@
 {% from "../../components/back-button/macro.njk" import backButton %}
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
+{% from "radios/macro.njk" import govukRadios %}
 {% extends "../../components/template.njk" %}
 
 {% block pageTitle %}
@@ -47,25 +48,36 @@
           <p class="govuk-body">Sudoku is a game that involves a grid of 81 squares, divided into nine blocks, each containing nine squares.</p>
           <p class="govuk-body">Each of the nine blocks has to contain the numbers 1-9, each number can only appear once in a row, column or box. Each vertical nine-square column, or horizontal nine-square line across, within the larger square, must also contain the numbers 1-9, without repetition or omission.</p>
           <p class="govuk-body">Each sudoku puzzle has only one correct solution.</p>
-          <p class="govuk-body">Difficulty level</p>
-          <div>
-            <label for="sudoku-difficulty-easy">
-              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-easy" value="easy">
-              Easy
-            </label>
-            <label for="sudoku-difficulty-medium">
-              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-medium" value="medium">
-              Medium
-            </label>
-            <label for="sudoku-difficulty-hard">
-              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-hard" value="hard">
-              Hard
-            </label>
-            <label for="sudoku-difficulty-veryhard">
-              <input type="radio" name="sudoku-difficulty" id="sudoku-difficulty-veryhard" value="very hard">
-              Very hard
-            </label>
-          </div>
+          {{ govukRadios({
+            classes: "govuk-radios--small",
+            idPrefix: "sudoku-difficulty",
+            name: "sudoku-difficulty",
+            fieldset: {
+              legend: {
+                text: "Difficulty level",
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--s"
+              }
+            },
+            items: [
+              {
+                value: "easy",
+                text: "Easy"
+              },
+              {
+                value: "medium",
+                text: "Medium"
+              },
+              {
+                value: "hard",
+                text: "Hard"
+              },
+              {
+                value: "very hard",
+                text: "Very hard"
+              }
+            ]
+          }) }}
           <p>
             <button id="new-game" class="govuk-button" title="Start a new game">Start a new game</button>
           </p>
@@ -88,32 +100,28 @@
   <script src="/public/jquery.min.js"></script>
   <script src="/public/javascript/games/sudoku/sudokuJS.js"></script>
   <script>
-    var mySudokuJS = $("#sudoku").sudokuJS({
-      difficulty: getLevel(),
-      boardFinishedFn: function (data) {
-        const message = "Congratulations \n\n You have completed the puzzle, would you like to play again?"
-        if (confirm(message)) {
-          mySudokuJS.generateBoard(getLevel());
-        };
-      }
-    });
-
-    /*window.setInterval(function(){
-      mySudokuJS.solveStep();
-  }, 100);*/
-
-    $("#new-game").on("click", function () {
-      alert(getLevel());
-      clearErrors();
-      mySudokuJS.generateBoard(getLevel());
-    });
-
-    function clearErrors() {
+    function newBoard() {
       $("#sudoku input").filter(function () {
         $(this).removeAttr('disabled');
         $(this).removeClass("board-cell--error highlight-val");
       });
+      mySudokuJS.clearBoard();
+      mySudokuJS.generateBoard(getLevel());
     }
+    var mySudokuJS = $("#sudoku").sudokuJS({
+      difficulty: getLevel(),
+      boardFinishedFn: function (data) {
+        const message = "Congratulations \n\n You have completed the puzzle, would you like to play again?";
+        if (confirm(message)) {
+          newBoard();
+        };
+      }
+    });
+
+    $("#new-game").on("click", function () {
+      newBoard();
+    });
+
     function getLevel() {
       return $("input[name='sudoku-difficulty']:checked").val() || 'easy';
     }


### PR DESCRIPTION
Currently it's very easy and the selection colours etc don't meet guidelines

- Add difficult level setting, default to easy on page load
- Add class to boxes to be the same as govuk inputs

Before
<img width="1214" alt="Screenshot 2019-07-16 at 12 50 22" src="https://user-images.githubusercontent.com/51918433/61292137-5a317800-a7c8-11e9-9ab5-831e74065440.png">

After
<img width="1237" alt="Screenshot 2019-07-16 at 12 49 55" src="https://user-images.githubusercontent.com/51918433/61292147-5ef62c00-a7c8-11e9-918b-78dcd012a53a.png">

