### PR TITLE
Remove contempt level from chess

### DIFF
--- a/moj-node/server/views/pages/games/chess.html
+++ b/moj-node/server/views/pages/games/chess.html
@@ -88,7 +88,7 @@
             <input type="hidden"  id="timeInc" value="2"/>
             {# </div> #}
 
-            <div class="govuk-form-group">
+            {# <div class="govuk-form-group">
               <label class="govuk-label" for="contemptLevel">
               Contempt Level (-100 to 100)
             </label>
@@ -103,7 +103,7 @@
                 Roughly equivalent to "optimism." Positive values of contempt favor more "risky" play, while negative values will favor draws. Zero is neutral.
               </div>
               </details>
-            </div>
+            </div> #}
             <div class="govuk-form-group">
 
               {{ govukRadios({


### PR DESCRIPTION
Contempt level is not understandable by inexperienced users, remove to reduce complexity

- Hardwire contempt level to neutral (0)
- Comment out contempt level option