### PR TITLE
Show secondary tags rather than primary

### DIFF
--- a/moj-be/modules/custom/moj_resources/src/ContentApiClass.php
+++ b/moj-be/modules/custom/moj_resources/src/ContentApiClass.php
@@ -134,7 +134,7 @@ class ContentApiClass
     $result["image"] =  $node->field_moj_thumbnail_image[0];
     $result["description"] =  $node->field_moj_description[0];
     $result["categories"] =  $node->field_moj_top_level_categories;
-    $result["secondary_tags"] =  $node->field_moj_tags;
+    $result["secondary_tags"] =  $node->field_moj_secondary_tags;
     $result["prisons"] =  $node->field_moj_prisons;
 
     return  $result;

--- a/moj-be/modules/custom/moj_resources/src/SeriesContentApiClass.php
+++ b/moj-be/modules/custom/moj_resources/src/SeriesContentApiClass.php
@@ -115,7 +115,7 @@ class SeriesContentApiClass
       $result["duration"] = $curr->field_moj_duration->value;
       $result["description"] = $curr->field_moj_description[0];
       $result["categories"] = $curr->field_moj_top_level_categories;
-      $result["secondary_tags"] = $curr->field_moj_tags;
+      $result["secondary_tags"] = $curr->field_moj_secondary_tags;
       $result["prisons"] = $curr->field_moj_prisons;
 
       if ($result["content_type"] === 'moj_radio_item') {

--- a/moj-node/server/utils/adapters.js
+++ b/moj-node/server/utils/adapters.js
@@ -98,7 +98,7 @@ function mediaResponseFrom(data) {
     episode: data.episode,
     season: data.season,
     seriesId: data.series_id,
-    tagsId: R.map(R.prop('target_id'), R.propOr([], 'categories', data)),
+    tagsId: R.map(R.prop('target_id'), R.propOr([], 'secondary_tags', data)),
     establishmentId: R.view(R.lensPath(['prisons', 0, 'target_id']))(data),
     contentUrl: `/content/${data.id}`,
   };

--- a/moj-node/test/resources/radioShow.json
+++ b/moj-node/test/resources/radioShow.json
@@ -17,7 +17,11 @@
       "target_id": 646
     }
   ],
-  "secondary_tags": [],
+  "secondary_tags": [
+    {
+      "target_id": 646
+    }
+  ],
   "prisons": [{ "target_id": 792 }],
   "media": {
     "url": "http://foo.bar.com/audio.mp3"

--- a/moj-node/test/resources/season.json
+++ b/moj-node/test/resources/season.json
@@ -23,7 +23,11 @@
         "target_id": 646
       }
     ],
-    "secondary_tags": [],
+    "secondary_tags": [
+      {
+        "target_id": 646
+      }
+    ],
     "prisons": [],
     "media": {
       "url": "http://foo.bar/audio/foo.mp3"

--- a/moj-node/test/utils/adapters.spec.js
+++ b/moj-node/test/utils/adapters.spec.js
@@ -237,7 +237,7 @@ function seasonContent() {
       media: 'http://foo.bar/audio/bar.mp3',
       season: '1',
       seriesId: 660,
-      tagsId: [785],
+      tagsId: [761],
       title: 'Radio Item 2',
       establishmentId: undefined,
       programmeCode: undefined,


### PR DESCRIPTION
Currently the tag links are showing the primnary tags, make them show the secondary.

- correct item response for secondary tags
- correct decorate series for secondary tags
- update mediaResponseFrom method for secondary tags