### PR TITLE
Temporarily remove home page events

### DIFF
--- a/moj-node/server/views/pages/index.html
+++ b/moj-node/server/views/pages/index.html
@@ -28,6 +28,7 @@
 {% endblock %}
 
 {% block todaysEvents %}
+{#
 <h2 class="govuk-heading-l">Today</h2>
 <div class="govuk-grid-row events">
   <div class="govuk-grid-column-one-quarter" id="morningEvents">
@@ -69,6 +70,7 @@
     </div>
   </div>
 </div>
+#}
 {% endblock %}
 
 {% set categoryLinks = {

--- a/moj-node/test/routes/index.spec.js
+++ b/moj-node/test/routes/index.spec.js
@@ -98,7 +98,7 @@ describe('GET /', () => {
       app.use(consoleLogError);
     });
 
-    it('renders todays events', () => {
+    it.skip('renders todays events', () => {
       return request(app)
         .get('/')
         .expect(200)
@@ -302,7 +302,7 @@ describe('GET /', () => {
         });
     });
 
-    it('does not render todays events', () => {
+    it.skip('does not render todays events', () => {
       return request(app)
         .get('/')
         .expect(200)


### PR DESCRIPTION
For security tests, temporarily remove content

- .skip two tests
- comment out home page block