### PR TITLE
Remove search from neontroids

### DIFF
--- a/moj-node/server/views/components/template.njk
+++ b/moj-node/server/views/components/template.njk
@@ -75,6 +75,8 @@
         user: user
       }) }}
 
+
+    {% block search %}
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -83,6 +85,7 @@
       </div>
       <hr class="govuk-section-break govuk-section-break--m govuk-search-section-break--visible">
     </div>
+    {% endblock %}
 
     {% block header %}{% endblock %}
 

--- a/moj-node/server/views/pages/games/neontroids.html
+++ b/moj-node/server/views/pages/games/neontroids.html
@@ -27,6 +27,8 @@
   {{ backButton() }}
 {% endblock %}
 
+{% block search %}{% endblock %}
+
 {% block main %}
   <div class="neontroids">
     <canvas id='canvas' class="canvas"></canvas>


### PR DESCRIPTION
Currently the search pushes neontroids right down the page, after feedback remove the search page

- Turn search into a block
- Make block blank on neontroids