### PR TITLE
Remove unused govuk modules

### DIFF
--- a/moj-node/Dockerfile
+++ b/moj-node/Dockerfile
@@ -23,9 +23,6 @@ RUN apk add --update \
 
 # Generate styles
 RUN ./node_modules/node-sass/bin/node-sass $@ \
-  --include-path node_modules/govuk_frontend_toolkit/stylesheets \
-  --include-path node_modules/govuk_template_jinja/assets/stylesheets \
-  --include-path node_modules/govuk-elements-sass/public/sass \
   /home/node/app/assets/sass/style.scss \
   /home/node/app/assets/stylesheets/application.css
 

--- a/moj-node/bin/build-css
+++ b/moj-node/bin/build-css
@@ -1,8 +1,5 @@
 #!/bin/bash
 
 ./node_modules/node-sass/bin/node-sass $@ \
-    --include-path node_modules/govuk_frontend_toolkit/stylesheets \
-    --include-path node_modules/govuk_template_jinja/assets/stylesheets \
-    --include-path node_modules/govuk-elements-sass/public/sass \
     assets/sass/style.scss \
     assets/stylesheets/application.css

--- a/moj-node/package-lock.json
+++ b/moj-node/package-lock.json
@@ -4505,35 +4505,10 @@
         "url-parse-lax": "^1.0.0"
       }
     },
-    "govuk-elements-sass": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/govuk-elements-sass/-/govuk-elements-sass-3.1.3.tgz",
-      "integrity": "sha512-uLg/LHSrylkXDKVPlz9uQtdAOQ2CG4rwxPBmQGO5c5QqW4OS83gspNEDaM/dzK2n2OduiieynfkwKbtqR89xiA==",
-      "requires": {
-        "govuk_frontend_toolkit": "^7.1.0"
-      },
-      "dependencies": {
-        "govuk_frontend_toolkit": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.6.0.tgz",
-          "integrity": "sha1-sJpgYxr7ukv6x2qLfALnJBnCnPU="
-        }
-      }
-    },
     "govuk-frontend": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/govuk/-/govuk-frontend-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
       "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
-    },
-    "govuk_frontend_toolkit": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/govuk_frontend_toolkit/-/govuk_frontend_toolkit-8.2.0.tgz",
-      "integrity": "sha512-USdHnptTl7HPHb9XZbyEK63lL66bzPl/pQLNMURFIXhhZCbW2gJglwMzTMHxdkgkWfKERiDocjsiukClHZ+opw=="
-    },
-    "govuk_template_jinja": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/govuk_template_jinja/-/govuk_template_jinja-0.26.0.tgz",
-      "integrity": "sha512-peTKDMzLJvj4YxOK1NqPQEcsplsz13XmJ0cNIuzZfeGHX60uEnw6cxSlLY9o7rLtppBorAY9EiBTAODHKBII1Q=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/moj-node/package.json
+++ b/moj-node/package.json
@@ -21,6 +21,10 @@
     "verify": "npm run lint && npm run prettier -- --list-different && npm run test",
     "format": "npm run prettier -- --write"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ministryofjustice/digital-hub/"
+  },
   "engines": {
     "node": ">= 10.15.3",
     "npm": ">=6.4.1"
@@ -56,10 +60,7 @@
     "express": "~4.16.4",
     "express-ntlm": "^2.3.0",
     "express-request-id": "^1.4.1",
-    "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^3.0.0",
-    "govuk_frontend_toolkit": "^8.2.0",
-    "govuk_template_jinja": "^0.26.0",
     "helmet": "^3.16.0",
     "jplayer": "^2.9.2",
     "jquery": "^3.4.1",

--- a/moj-node/server/app.js
+++ b/moj-node/server/app.js
@@ -97,11 +97,6 @@ module.exports = function createApp({
         debug: true,
         outputStyle: 'compressed',
         prefix: '/stylesheets/',
-        includePaths: [
-          'node_modules/govuk_frontend_toolkit/stylesheets',
-          'node_modules/govuk_template_jinja/assets/stylesheets',
-          'node_modules/govuk-elements-sass/public/sass',
-        ],
       }),
     );
   }
@@ -122,8 +117,6 @@ module.exports = function createApp({
     '../public',
     '../assets',
     '../assets/stylesheets',
-    '../node_modules/govuk_template_jinja/assets',
-    '../node_modules/govuk_frontend_toolkit',
     '../node_modules/govuk-frontend/govuk/',
     '../node_modules/jplayer/dist',
     '../node_modules/jquery/dist',
@@ -139,13 +132,6 @@ module.exports = function createApp({
       cacheControl,
     ),
   );
-
-  ['../node_modules/govuk_frontend_toolkit/images'].forEach(dir => {
-    app.use(
-      '/public/images/icons',
-      express.static(path.join(__dirname, dir), cacheControl),
-    );
-  });
 
   // GovUK Template Configuration
   app.locals.asset_path = '/public/';


### PR DESCRIPTION
After installing the govuk module for accessibility updates we need to remove deprecated modules

- Remove govuk_frontend_toolkit
- Remove govuk-elements-sass
- Remove govuk_frontend_jinja