### PR TITLE
Expose remaining visits

### DIFF
--- a/moj-node/server/repositories/offender.js
+++ b/moj-node/server/repositories/offender.js
@@ -1,3 +1,4 @@
+const { format } = require('date-fns');
 const config = require('../config');
 
 function offenderRepository(httpClient) {
@@ -35,6 +36,15 @@ function offenderRepository(httpClient) {
     );
   }
 
+  function getRemainingVisitsFor(bookingId) {
+    return httpClient.get(
+      `${config.nomis.api.bookings}/${bookingId}/visits?fromDate=${format(
+        new Date(),
+        'YYYY-MM-DD',
+      )}`,
+    );
+  }
+
   function sentenceDetailsFor(bookingId) {
     return httpClient.get(
       `${config.nomis.api.bookings}/${bookingId}/sentenceDetail`,
@@ -54,6 +64,7 @@ function offenderRepository(httpClient) {
     getKeyWorkerFor,
     getNextVisitFor,
     getLastVisitFor,
+    getRemainingVisitsFor,
     sentenceDetailsFor,
     getEventsForToday,
   };

--- a/moj-node/server/services/offender.js
+++ b/moj-node/server/services/offender.js
@@ -117,10 +117,12 @@ module.exports = function createOffenderService(repository) {
   async function getVisitsFor(bookingId) {
     const lastVisit = await repository.getLastVisitFor(bookingId);
     const nextVisit = await repository.getNextVisitFor(bookingId);
+    const remainingVisits = await repository.getRemainingVisitsFor(bookingId);
 
     return {
       lastVisit: prettyDate(prop('startTime', lastVisit)),
       nextVisit: prettyDate(prop('startTime', nextVisit)),
+      remainingVisits: remainingVisits.length,
     };
   }
 

--- a/moj-node/server/views/pages/me.html
+++ b/moj-node/server/views/pages/me.html
@@ -194,6 +194,14 @@
                 value: {
                   text: data.visits.lastVisit
                 }
+              },
+              {
+                key: {
+                  text: "Remaining visits"
+                },
+                value: {
+                  text: data.visits.remainingVisits
+                }
               }
             ]
           })

--- a/moj-node/test/repositories/offenderRepository.spec.js
+++ b/moj-node/test/repositories/offenderRepository.spec.js
@@ -79,6 +79,19 @@ describe('offenderRepository', () => {
     });
   });
 
+  describe('#getRemainingVisitsFor', () => {
+    it('calls the allVisits endpoint for a given ID from today', async () => {
+      const client = {
+        get: sinon.stub().resolves('SOME_RESULT'),
+      };
+      const repository = offenderRepository(client);
+      const result = await repository.getRemainingVisitsFor('FOO_ID');
+
+      expect(client.get.lastCall.args[0]).to.include('/FOO_ID/visits');
+      expect(result).to.equal('SOME_RESULT');
+    });
+  });
+
   describe('#sentenceDetailsFor', () => {
     it('calls the sentenceDetails endpoint for a given ID', async () => {
       const client = {

--- a/moj-node/test/services/offenderService.spec.js
+++ b/moj-node/test/services/offenderService.spec.js
@@ -105,16 +105,25 @@ describe('Offender Service', () => {
         getNextVisitFor: sinon.stub().returns({
           startTime: '2019-12-07T11:30:30',
         }),
+        getRemainingVisitsFor: sinon.stub().returns([
+          {
+            startTime: '2019-12-07T11:30:30',
+          },
+        ]),
       };
       const service = offenderService(repository);
       const data = await service.getVisitsFor('FOO_ID');
 
       expect(repository.getLastVisitFor.lastCall.args[0]).to.equal('FOO_ID');
       expect(repository.getNextVisitFor.lastCall.args[0]).to.equal('FOO_ID');
+      expect(repository.getRemainingVisitsFor.lastCall.args[0]).to.equal(
+        'FOO_ID',
+      );
 
       expect(data).to.eql({
         lastVisit: 'Tuesday 11 February 2014',
         nextVisit: 'Saturday 07 December 2019',
+        remainingVisits: 1,
       });
     });
   });


### PR DESCRIPTION
Currently we show next and previous visits, expose number of upcoming visits

- Added call to all visits endpoint with date
- Return number of remaining visits in existing visits service