### PR TITLE
Fix old secondary tags not being returned

### DIFF
--- a/moj-be/modules/custom/moj_resources/src/ContentApiClass.php
+++ b/moj-be/modules/custom/moj_resources/src/ContentApiClass.php
@@ -134,7 +134,11 @@ class ContentApiClass
     $result["image"] =  $node->field_moj_thumbnail_image[0];
     $result["description"] =  $node->field_moj_description[0];
     $result["categories"] =  $node->field_moj_top_level_categories;
-    $result["secondary_tags"] =  $node->field_moj_secondary_tags;
+    if ($node->field_moj_secondary_tags) {
+      $result["secondary_tags"] =  $node->field_moj_secondary_tags;
+    } else {
+      $result["secondary_tags"] =  $node->field_moj_tags;
+    }
     $result["prisons"] =  $node->field_moj_prisons;
 
     return  $result;

--- a/moj-be/modules/custom/moj_resources/src/SeriesContentApiClass.php
+++ b/moj-be/modules/custom/moj_resources/src/SeriesContentApiClass.php
@@ -115,7 +115,11 @@ class SeriesContentApiClass
       $result["duration"] = $curr->field_moj_duration->value;
       $result["description"] = $curr->field_moj_description[0];
       $result["categories"] = $curr->field_moj_top_level_categories;
-      $result["secondary_tags"] = $curr->field_moj_secondary_tags;
+      if ($curr->field_moj_secondary_tags) {
+        $result["secondary_tags"] = $curr->field_moj_secondary_tags;
+      } else {
+        $result["secondary_tags"] = $curr->field_moj_tags;
+      }
       $result["prisons"] = $curr->field_moj_prisons;
 
       if ($result["content_type"] === 'moj_radio_item') {


### PR DESCRIPTION
Older content items have an different field for secondary tags, ensure these are still returned.

- Used an if statement to ensure correct field