### PR TITLE
Bug Fix: Stop using govuk-footer

### DIFF
--- a/moj-node/server/views/components/template.njk
+++ b/moj-node/server/views/components/template.njk
@@ -121,7 +121,22 @@
     {% endif %}
 
     {% block footer %}
-      {{ govukFooter({}) }}
+      <footer class="govuk-footer " role="contentinfo">
+        <div class="govuk-width-container ">
+          <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+              <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+                <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+              </svg>
+              <span class="govuk-footer__licence-description">
+                All content is available under the Open Government Licence v3.0, except where otherwise stated
+              </span>
+            </div>
+            <div class="govuk-footer__meta-item govuk-footer__copyright-logo">© Crown copyright</div>
+          </div>
+        </div>
+      </footer>
     {% endblock %}
 
     <script src="/public/jquery.min.js"></script>


### PR DESCRIPTION
It seems we don't want the links it contains so we're unable to use it.

- Copy footer html into our template
- Remove links