### PR TITLE
Make establishment name required in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ jobs:
             ENABLE_PRISON_SWITCH="true" \
             HUB_API_ENDPOINT="https://drupal.digital-hub-stage.hmpps.dsd.io" \
             ELASTICSEARCH_ENDPOINT="UNSET" \
+            ESTABLISHMENT_NAME="berwyn" \
             npm run test:e2e:run
       - store_artifacts:
           path: ./moj-node/cypress/videos

--- a/moj-node/server/config.js
+++ b/moj-node/server/config.js
@@ -25,7 +25,9 @@ module.exports = {
   matomoUrl,
   backendUrl,
   cookieSecret: getEnv('COOKIE_SECRET', 'keyboard cat'),
-  establishmentName: getEnv('ESTABLISHMENT_NAME', 'berwyn'),
+  establishmentName: getEnv('ESTABLISHMENT_NAME', 'berwyn', {
+    requireInProduction: true,
+  }),
   hubEndpoint,
   ldap: {
     domain: getEnv('FQDN', 'MYDOMAIN'),


### PR DESCRIPTION
Establishment name is not currently required in production, if we were to miss this configuration
our site will default to an establishment. Making this required will cause the application to
throw an error if this configuration is missing and not default.

Notes:

* Dev/Staging configuration will need updating