### PR TITLE
Sort helmet deprecation warning

### DIFF
--- a/moj-node/package.json
+++ b/moj-node/package.json
@@ -64,6 +64,7 @@
     "jquery": "^3.5.0",
     "ldap-authentication": "^2.1.3",
     "mkdirp": "^1.0.4",
+    "nocache": "^2.1.0",
     "node-sass-middleware": "0.11.0",
     "nunjucks": "^3.2.1",
     "ramda": "^0.27.0",

--- a/moj-node/server/app.js
+++ b/moj-node/server/app.js
@@ -5,6 +5,7 @@ const express = require('express');
 const addRequestId = require('express-request-id')();
 const compression = require('compression');
 const helmet = require('helmet');
+const noCache = require('nocache');
 const nunjucks = require('nunjucks');
 const path = require('path');
 const fs = require('fs');
@@ -152,7 +153,7 @@ const createApp = ({
   };
 
   // Don't cache dynamic resources
-  app.use(helmet.noCache());
+  app.use(noCache());
 
   app.use(logger.requestLogger());
 

--- a/moj-node/test/services/offenderService.spec.js
+++ b/moj-node/test/services/offenderService.spec.js
@@ -171,7 +171,9 @@ describe('Offender Service', () => {
         }),
       };
       const service = createNomisOffenderService(repository);
-      await service.getEventsForToday('FOO_ID');
+      const dateBeforeCutOff = new Date();
+      dateBeforeCutOff.setHours(7);
+      await service.getEventsForToday('FOO_ID', dateBeforeCutOff);
 
       expect(repository.getEventsForToday.lastCall.args[0]).to.equal('FOO_ID');
     });
@@ -182,7 +184,12 @@ describe('Offender Service', () => {
           getEventsForToday: sinon.stub().returns(singleTestData.repo),
         };
         const service = createNomisOffenderService(repository);
-        const data = await service.getEventsForToday('FOO_ID');
+        const dateBeforeCutOff = new Date();
+        dateBeforeCutOff.setHours(7);
+        const data = await service.getEventsForToday(
+          'FOO_ID',
+          dateBeforeCutOff,
+        );
 
         expect(data).to.eql(singleTestData.data);
       });


### PR DESCRIPTION
So this was kind of amusing. If you ran the tests after the cut-off point (7pm) they failed as it tried to pull data for tomorrow 😆 

- Replace helmet.noCache() with noCache() as per helmet docs.
- Fix tests for running at any time.